### PR TITLE
Quickstart: check if action is run in context of template repository by looking at `github.event.repository.template_repository`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -200,7 +200,7 @@ jobs:
     # 1. This repository isn't the template repository
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'githublearn' }}
+    if: ${{ github.event.repository.template_repository != "" }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Why:

Checking for `github.event.repository.template_repository` makes it work for all courses, not only `githublearn/*` repositories

### What's being changed:

Just a suggestion. But I think this makes it more generic?

I originally thought the expression was incorrect because on https://githublearn.github.io/.github/quickstart it only shows 

```
    if: $
```

But that seems to be an unrelated rendering problem?

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/39992/157508642-0f376618-34a8-4852-b4a4-b896c4f5ef84.png">

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
