### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,9 +60,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
-All complaints will be reviewed and investigated promptly and fairly.
+reported to the community leaders responsible for enforcement by using GitHub’s
+private reporting tool at https://github.com/contact/report-abuse, or by
+contacting a project maintainer directly via GitHub. All complaints will be
+reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
Added a contact method for enforcement

### Summary
The code of conduct is the default template and does not list a contact method for enforcement. I added a line that points to GitHub's reporting tool.


### Changes
Added this line `by using GitHub’s private reporting tool at https://github.com/contact/report-abuse, or by contacting a project maintainer directly via GitHub.` to code of conduct


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [X] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
