### PR TITLE
Update style guide URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Please note that this project is released with a Contributor Code of Conduct. By
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Follow the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
+- Follow the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).
 - Verify your actions workflows work as expected.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).


### PR DESCRIPTION
### Summary
CONTRIBUTING.md contains a link to a page that is no longer being maintained. 


### Changes
It is updated to now direct to GitHub's maintained Style Guide reference docs.