### PR TITLE
docs: add important resources to skills org profile readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # GitHub Skills
 
-_This is not a course._ See https://skills.github.com for our list of available courses.
+_This is not an exercise._ See https://learn.github.com/skills for our list of available exercises.
 
 See [profile/README.md](profile/README.md) for more information about GitHub Skills. If you'd like to provide any feedback, please start a new [discussion](https://github.com/orgs/skills/discussions).
 
-See the [GitHub Skills Quickstart Guide](https://skills.github.com/quickstart) to learn how to build your own Actions-backed courses. See [CONTENT_MODEL.md](https://skills.github.com/content-model) for more information about how to write the content for GitHub Skills courses.
-
-&copy; 2023 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+See the [Exercise Creator](https://github.com/skills/exercise-creator) to learn how to build your own exercises about any topic.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,4 @@
 
 _This is not an exercise._ See https://learn.github.com/skills for our list of available exercises.
 
-See [profile/README.md](profile/README.md) for more information about GitHub Skills. If you'd like to provide any feedback, please start a new [discussion](https://github.com/orgs/skills/discussions).
-
-See the [Exercise Creator](https://github.com/skills/exercise-creator) to learn how to build your own exercises about any topic.
+See [profile/README.md](profile/README.md) for more information about GitHub Skills.

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,13 +2,21 @@
 
 <img alt="" src=https://user-images.githubusercontent.com/1221423/156894097-ff2d6566-7b6a-4488-950e-f4ebe990965a.svg width=200 align=right>
 
-_Learn how to use GitHub with interactive courses designed for beginners and experts._
+_Learn how to use GitHub with interactive exercises designed for beginners and experts._
 
 - **Learning should be fun**: There are no simulations or boring tutorials here, just hands-on lessons created by GitHub and taught inside Issues using GitHub Actions.
 - **Real projects**: Learn new skills while working in your own copy of a real project.
 - **Helpful guidance**: Your favorite Octocat provides instructions and feedback throughout your journey.
 - **Real workflow**: Everything happens with real GitHub features, such as Issues, Actions, and Codespaces.
 
-Get started building your own exercises with the same tooling the team uses. 🌟
+Use these resources to discover, create, and help us improve GitHub Skills:
 
-Check out [Skills Exercise Creator](https://github.com/skills/exercise-creator) for a 10min guide on using :copilot: Copilot to generate your own exercise!
+| Resource                                                                             | Description                                                            |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| :mortar_board: [GitHub Learn: Skills catalog](https://learn.github.com/skills)       | Browse the full catalog of available Skills exercises.                                          |
+| :clipboard: [Project Board](https://github.com/orgs/skills/projects/6/views/2)       | Tracking valid user reported issues and PR's across all Skills exercises.                       |
+| :construction_worker: [Exercise Creator](https://github.com/skills/exercise-creator) | Documentation and tooling for creating new exercises and updating existing ones.                |
+| :package: [Exercise Template](https://github.com/skills/exercise-template)           | Repository template to use when creating a new exercise.                                        |
+| :toolbox: [Exercise Toolkit](https://github.com/skills/exercise-toolkit)             | Reusable resources used across exercises, including workflows, actions, and markdown templates. |
+| :bookmark_tabs: [Changelog](https://github.com/skills/releases)                      | Monthly  release notes for exercise and platform updates across Skills repositories.         |
+| :office: [Skills for EMU](https://github.com/skills/skills-for-emu)                  | Guidelines on enabling GitHub Skills for Enterprise Managed User organizations.                 |


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates documentation to improve clarity and provide more helpful resources for users interested in GitHub Skills. The main changes focus on shifting terminology from "courses" to "exercises", updating resource links, and enhancing the resource list for users and contributors.

Documentation and terminology updates:

* Updated the `README.md` file to refer to "exercises" instead of "courses", revised the main resource link to https://learn.github.com/skills, and removed outdated or redundant resource links and copyright/license information.
* Revised `profile/README.md` to use "exercises" instead of "courses", and replaced the previous encouragement to build exercises with a comprehensive table of key resources for discovering, creating, and contributing to GitHub Skills exercises. This includes links to the Skills catalog, project board, exercise creator, template, toolkit, changelog, and EMU guidelines.

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
