### PR TITLE
fix: update CODEOWNERS for content and technical reviewers team names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*.md @skills/skills-content-reviewers
-*.yml @skills/skills-technical-reviewers
+*.md @skills/content-reviewers
+*.yml @skills/technical-reviewers


### PR DESCRIPTION
I think the teams must have been renamed since. Updating to current names fyi @chriswblake @arilivigni 

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates the `CODEOWNERS` file to use the correct GitHub team names for content and technical reviewers. The new team names better reflect the current team structure.

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
